### PR TITLE
fix: id:39217 textfield and select component fixes

### DIFF
--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -129,7 +129,7 @@ class App extends React.Component<{}, State> {
       appName: '',
       appDescription: '',
       appCity: '',
-      appCity1: null,
+      appCity1: '',
       appTextCounter: '',
       appTextCounter1: '',
       checkboxState: true,
@@ -1652,7 +1652,7 @@ class App extends React.Component<{}, State> {
             helpText="Helper Text"
             maxLength={100}
             // onChange={this.valueUpdater('appTextCounter')}
-            connectedRight={<Select label="Weight unit" labelHidden options={[
+            connectedRight={<Select label="Weight unit" value="" labelHidden options={[
               'kg',
               'lb',
             ]} />}

--- a/src/components/Select/Select.tsx
+++ b/src/components/Select/Select.tsx
@@ -56,7 +56,7 @@ export interface Props {
   onBlur?(): void;
 }
 
-const PLACEHOLDER_VALUE = '__placeholder__';
+const PLACEHOLDER_VALUE = '';
 const getUniqueID = createUniqueIDFactory('Select');
 
 const select = ({
@@ -69,7 +69,7 @@ const select = ({
   helpText,
   label,
   errors,
-  value,
+  value = PLACEHOLDER_VALUE,
   placeholder,
   disabled,
   required,
@@ -86,7 +86,7 @@ const select = ({
     optionsMarkup = groups.map(renderGroup);
   }
 
-  const isPlaceholder = value == null && placeholder != null;
+  const isPlaceholder = value === '' && placeholder != null;
   const className = classNames(
     theme.select,
     Boolean(value) && theme.hasValue,
@@ -133,7 +133,6 @@ const select = ({
           id={componentId}
           name={name ? name : 'select'}
           value={value}
-          defaultValue={PLACEHOLDER_VALUE}
           className={theme.input}
           disabled={disabled}
           required={required}

--- a/src/components/Select/tests/Select.test.tsx
+++ b/src/components/Select/tests/Select.test.tsx
@@ -144,7 +144,7 @@ describe('<Select />', () => {
       const select = mount(<Select label="Select" placeholder="Choose something" options={['one']} />);
       const placeholderOption = select.find('option').first();
 
-      expect(placeholderOption.prop('value')).toBe(select.find('select').at(1).prop('defaultValue'));
+      expect(placeholderOption.prop('value')).toBe('');
       expect(placeholderOption.prop('disabled')).toBe(true);
       expect(placeholderOption.prop('hidden')).toBe(true);
     });

--- a/src/components/TextField/TextField.tsx
+++ b/src/components/TextField/TextField.tsx
@@ -135,7 +135,6 @@ class TextField extends React.PureComponent<Props, State> {
       helpText,
       enableTextCounter,
       maxLength,
-      minLength,
       prefix,
       suffix,
       required,
@@ -189,7 +188,7 @@ class TextField extends React.PureComponent<Props, State> {
     if (enableTextCounter) {
       const maxLengthString = maxLength ? '/' + maxLength : '';
       const textCount = this.props.value ? this.props.value.toString().length : 0;
-      const minLengthTest = minLength ? minLength : 0;
+      const minLengthTest = this.props.minLength ? this.props.minLength : 0;
       counterTextMarkup =
         <div className={theme.counterText} id={`${componentId}counter`}>
           <span className={minLengthTest > textCount ? theme.invalid : ''}>{textCount}</span>
@@ -213,13 +212,13 @@ class TextField extends React.PureComponent<Props, State> {
     const input = React.createElement(multiline ? 'textarea' : 'input', {
       ...rest,
       name,
-      componentId,
       type,
       disabled,
       readOnly,
       autoFocus,
       placeholder,
       required,
+      id: componentId,
       value: this.state.value,
       onFocus: this.handleInputOnFocus,
       onBlur: this.handleInputOnBlur,

--- a/src/components/TextField/tests/TextField.test.tsx
+++ b/src/components/TextField/tests/TextField.test.tsx
@@ -30,6 +30,7 @@ describe('<TextField />', () => {
     expect(input.prop('value')).toBe('Some value');
     expect(input.prop('min')).toBe(20);
     expect(input.prop('max')).toBe(50);
+    expect(input.prop('minLength')).toBe(2);
     expect(input.prop('spellCheck')).toBe(false);
     expect(input.prop('pattern')).toBe(pattern);
   });

--- a/src/components/TextField/tests/TextField.test.tsx
+++ b/src/components/TextField/tests/TextField.test.tsx
@@ -64,12 +64,12 @@ describe('<TextField />', () => {
 
   describe('id', () => {
     it('sets the id on the input', () => {
-      const id = mount(<TextField label="TextField" componentId="MyField" />).find('input').prop('componentId');
+      const id = mount(<TextField label="TextField" componentId="MyField" />).find('input').prop('id');
       expect(id).toBe('MyField');
     });
 
     it('sets a random id on the input when none is passed', () => {
-      const id = mount(<TextField label="TextField" />).find('input').prop('componentId');
+      const id = mount(<TextField label="TextField" />).find('input').prop('id');
       expect(typeof id).toBe('string');
       expect(id).toBeTruthy();
     });

--- a/src/components/ValidatedTextField/tests/ValidatedTextField.test.tsx
+++ b/src/components/ValidatedTextField/tests/ValidatedTextField.test.tsx
@@ -21,7 +21,7 @@ describe('<ValidatedTextField / >', () => {
   expect(validatedTextFieldWrapper.find('input').prop('name')).toBe('App Name');
   expect(validatedTextFieldWrapper.find('label').at(1).prop('id')).toBe('AppNameLabel');
   expect(validatedTextFieldWrapper.find('label').at(1).text()).toBe('App Name');
-  expect(validatedTextFieldWrapper.find('input').prop('componentId')).toBe('AppName');
+  expect(validatedTextFieldWrapper.find('input').prop('id')).toBe('AppName');
   expect(validatedTextFieldWrapper.find('input').prop('name')).toBe('App Name');
   expect(validatedTextFieldWrapper.find('input').prop('value')).toBe('');
     });
@@ -44,7 +44,7 @@ describe('<ValidatedTextField / >', () => {
         expect(validatedTextFieldWrapper.find('input').prop('name')).toBe('App Name');
         expect(validatedTextFieldWrapper.find('label').at(1).prop('id')).toBe('AppNameLabel');
         expect(validatedTextFieldWrapper.find('label').at(1).text()).toBe('App Name');
-        expect(validatedTextFieldWrapper.find('input').prop('componentId')).toBe('AppName');
+        expect(validatedTextFieldWrapper.find('input').prop('id')).toBe('AppName');
         expect(validatedTextFieldWrapper.find('input').prop('name')).toBe('App Name');
         expect(validatedTextFieldWrapper.find('input').prop('value')).toBe('');
       });
@@ -68,7 +68,7 @@ describe('<ValidatedTextField / >', () => {
         expect(validatedTextFieldWrapper.find('input').prop('name')).toBe('App Name');
         expect(validatedTextFieldWrapper.find('label').at(1).prop('id')).toBe('AppNameLabel');
         expect(validatedTextFieldWrapper.find('label').at(1).text()).toBe('App Name');
-        expect(validatedTextFieldWrapper.find('input').prop('componentId')).toBe('AppName');
+        expect(validatedTextFieldWrapper.find('input').prop('id')).toBe('AppName');
         expect(validatedTextFieldWrapper.find('input').prop('name')).toBe('App Name');
         expect(validatedTextFieldWrapper.find('input').prop('value')).toBe('');
       });
@@ -99,7 +99,7 @@ describe('<ValidatedTextField / >', () => {
         expect(validatedTextFieldWrapper.find('input').prop('name')).toBe('App Name');
         expect(validatedTextFieldWrapper.find('label').at(1).prop('id')).toBe('AppNameLabel');
         expect(validatedTextFieldWrapper.find('label').at(1).text()).toBe('App Name');
-        expect(validatedTextFieldWrapper.find('input').prop('componentId')).toBe('AppName');
+        expect(validatedTextFieldWrapper.find('input').prop('id')).toBe('AppName');
         expect(validatedTextFieldWrapper.find('input').prop('name')).toBe('App Name');
         expect(validatedTextFieldWrapper.find('input').prop('value')).toBe('Test');
         expect(validatedTextFieldWrapper.find('input').prop('required')).toBe(true);
@@ -131,7 +131,7 @@ describe('<ValidatedTextField / >', () => {
         expect(validatedTextFieldWrapper.find('input').prop('name')).toBe('App Name');
         expect(validatedTextFieldWrapper.find('label').at(1).prop('id')).toBe('AppNameLabel');
         expect(validatedTextFieldWrapper.find('label').at(1).text()).toBe('App Name');
-        expect(validatedTextFieldWrapper.find('input').prop('componentId')).toBe('AppName');
+        expect(validatedTextFieldWrapper.find('input').prop('id')).toBe('AppName');
         expect(validatedTextFieldWrapper.find('input').prop('name')).toBe('App Name');
         expect(validatedTextFieldWrapper.find('input').prop('value')).toBe('');
         expect(validatedTextFieldWrapper.find('input').prop('required')).toBe(true);
@@ -160,7 +160,7 @@ describe('<ValidatedTextField / >', () => {
         expect(validatedTextFieldWrapper.find('input').prop('name')).toBe('App Name');
         expect(validatedTextFieldWrapper.find('label').at(1).prop('id')).toBe('AppNameLabel');
         expect(validatedTextFieldWrapper.find('label').at(1).text()).toBe('App Name');
-        expect(validatedTextFieldWrapper.find('input').prop('componentId')).toBe('AppName');
+        expect(validatedTextFieldWrapper.find('input').prop('id')).toBe('AppName');
         expect(validatedTextFieldWrapper.find('input').prop('name')).toBe('App Name');
         expect(validatedTextFieldWrapper.find('input').prop('value')).toBe('Test');
         expect(validatedTextFieldWrapper.find('input').prop('required')).toBe(true);
@@ -192,7 +192,7 @@ describe('<ValidatedTextField / >', () => {
         expect(validatedTextFieldWrapper.find('input').prop('name')).toBe('App Name');
         expect(validatedTextFieldWrapper.find('label').at(1).prop('id')).toBe('AppNameLabel');
         expect(validatedTextFieldWrapper.find('label').at(1).text()).toBe('App Name');
-        expect(validatedTextFieldWrapper.find('input').prop('componentId')).toBe('AppName');
+        expect(validatedTextFieldWrapper.find('input').prop('id')).toBe('AppName');
         expect(validatedTextFieldWrapper.find('input').prop('name')).toBe('App Name');
         expect(validatedTextFieldWrapper.find('input').prop('value')).toBe('');
         expect(validatedTextFieldWrapper.find('input').prop('required')).toBe(true);
@@ -222,7 +222,7 @@ describe('<ValidatedTextField / >', () => {
         expect(validatedTextFieldWrapper.find('input').prop('name')).toBe('App Name');
         expect(validatedTextFieldWrapper.find('label').at(1).prop('id')).toBe('AppNameLabel');
         expect(validatedTextFieldWrapper.find('label').at(1).text()).toBe('App Name');
-        expect(validatedTextFieldWrapper.find('input').prop('componentId')).toBe('AppName');
+        expect(validatedTextFieldWrapper.find('input').prop('id')).toBe('AppName');
         expect(validatedTextFieldWrapper.find('input').prop('name')).toBe('App Name');
         expect(validatedTextFieldWrapper.find('input').prop('value')).toBe('');
         expect(validatedTextFieldWrapper.find('input').prop('required')).toBe(true);
@@ -257,7 +257,7 @@ describe('<ValidatedTextField / >', () => {
         expect(validatedTextFieldWrapper.find('input').prop('name')).toBe('App Name');
         expect(validatedTextFieldWrapper.find('label').at(1).prop('id')).toBe('AppNameLabel');
         expect(validatedTextFieldWrapper.find('label').at(1).text()).toBe('App Name');
-        expect(validatedTextFieldWrapper.find('input').prop('componentId')).toBe('AppName');
+        expect(validatedTextFieldWrapper.find('input').prop('id')).toBe('AppName');
         expect(validatedTextFieldWrapper.find('input').prop('name')).toBe('App Name');
         expect(validatedTextFieldWrapper.find('input').prop('value')).toBe('Text Value');
         expect(validatedTextFieldWrapper.find('input').prop('required')).toBe(true);


### PR DESCRIPTION
Fixed the TextField component minLength issue. Also fixed he following issues with the Select component:

- React was complaining that value in not allowed to be null
- Changed default placeholder value to empty

and the following issue with TextField:

- input id was not being set properly