### PR TITLE
Fix react missing keys error in Table

### DIFF
--- a/src/components/Table/Table.tsx
+++ b/src/components/Table/Table.tsx
@@ -342,8 +342,8 @@ class Table extends React.Component<Props, State> {
       if (selectRow) totalColumn++;
     }
     return(
-      <React.Fragment>
-        <TableRow key={index} theme={theme}>
+      <React.Fragment key={index}>
+        <TableRow theme={theme}>
           { this.renderRowSelection(item, 'body') }
           {
             column.map((colItem: any, index: number) => {


### PR DESCRIPTION
Fix #441 
Just moved the `key` prop to the right place.

All tests still pass with `npm run test`.