### PR TITLE
fix: 44662 fix ERROR in [at-loader]

### DIFF
--- a/src/components/ChoiceList/ChoiceList.tsx
+++ b/src/components/ChoiceList/ChoiceList.tsx
@@ -72,7 +72,7 @@ class ChoiceList extends React.PureComponent<Props, {}> {
       componentName = getUniqueID(),
     } = this.props;
 
-    const CONTROLCOMPONENT = allowMultiple ? Checkbox : RadioButton;
+    const CONTROLCOMPONENT: any = allowMultiple ? Checkbox : RadioButton;
     const finalName = allowMultiple ? `${componentName}[]` : componentName;
     const className = classNames(theme.choiceList, titleHidden && theme.titleHidden);
     const titleMarkup = componentTitle

--- a/src/components/Tooltip/Tooltip.tsx
+++ b/src/components/Tooltip/Tooltip.tsx
@@ -80,7 +80,7 @@ class Tooltip extends React.PureComponent<Props, State> {
   }
 
   render() {
-    const { activatorWrapper: WRAPPERCOMPONENT = 'span' } = this.props;
+    const { activatorWrapper: WRAPPERCOMPONENT = 'span' }: any = this.props;
 
     return (
       <WRAPPERCOMPONENT


### PR DESCRIPTION
- `TS2604: JSX element type 'CONTROLCOMPONENT' does not have any construct or call signatures.`
- `TS2322: Type '{ children: ReactNode; onFocus: () => void; onBlur: () => void; onMouseEnter: () => void; onMouseLeave: () => void; ref: (node: HTMLElement) => void; }' is not assignable to type 'IntrinsicAttributes'. Property 'children' does not exist on type 'IntrinsicAttributes'.`
