### PR TITLE
Bugfix/44537: appOwner/appAdministratore dropdown issue on AppDef

### DIFF
--- a/src/components/Picker/Picker.tsx
+++ b/src/components/Picker/Picker.tsx
@@ -90,6 +90,8 @@ export interface Props {
   labelHidden?: boolean;
   // Display loading indicator
   loading?: boolean;
+  // Disable Picker
+  disabled: boolean;
   maxSelectedItems?: number;
   minSelectedItems?: number;
   chipComponent?: React.ReactNode;
@@ -292,6 +294,7 @@ class Picker extends React.Component<Props, State> {
         label,
         labelHidden,
         loading,
+        disabled,
         selectedResultsBehavior,
         moreInfoComponent,
         chipComponent,
@@ -337,7 +340,7 @@ class Picker extends React.Component<Props, State> {
             }
           </div>
           <TextField
-            autoSuggest={autoSuggest}
+            autoSuggest={autoSuggest && !disabled}
             autoSuggestMethods={autoSuggestMethods}
             helpText={helpText}
             itemSelected={!!chipListState.length}
@@ -351,6 +354,7 @@ class Picker extends React.Component<Props, State> {
             suffix={suffixIcon}
             isFocused={isFocused}
             hasValue={hasValue}
+            disabled={disabled}
           />
         </div>
         <div>


### PR DESCRIPTION
This PR resolved [44537](https://atera.tpondemand.com/RestUI/Board.aspx#page=board/4941726065867675222&appConfig=eyJhY2lkIjoiOTEwQzZFODEyODVCQ0Y4MTg5RUIyMEJEQTVDMEM2OUYifQ==&boardPopup=bug/44537/silent).