### PR TITLE
fix: id:45121 badge overlapped on content base type icon and name

### DIFF
--- a/src/components/Badge/Badge.scss
+++ b/src/components/Badge/Badge.scss
@@ -14,6 +14,11 @@ $spinner-spacing: ($height - $spinner-size - rem(4px)) / 2;
 $icon-size: rem(14px);
 $icon-spacing: ($height - $icon-size - rem(4px)) / 2;
 
+$stacking-order: (
+  icon: 1,
+);
+
+
 @mixin pip-color($color) {
   .pip {
     color: $color;
@@ -30,6 +35,9 @@ $icon-spacing: ($height - $icon-size - rem(4px)) / 2;
   font-size: rem(13px);
   line-height: ($height - rem(4px));
   color: color(ink);
+  z-index: z-index(icon, $stacking-order); 
+  width: 2rem;
+  height: 2rem;
 }
 
 .statusSuccess {


### PR DESCRIPTION
FE - Create ContentStore: Entity state badge shows large which is overlapped on content base type icon and contentdef name in step-1 Select Content Template