### PR TITLE
fix: badge remove width provided to badge

### DIFF
--- a/src/components/Badge/Badge.scss
+++ b/src/components/Badge/Badge.scss
@@ -36,7 +36,7 @@ $stacking-order: (
   line-height: ($height - rem(4px));
   color: color(ink);
   z-index: z-index(icon, $stacking-order); 
-  width: 2rem;
+  width: initial;
   height: 2rem;
 }
 


### PR DESCRIPTION
Badge width issue resolved , Badge displayed in circle