### PR TITLE
Bugfix/45191: Date->year limitation issue on Date/DateTime widgets

### DIFF
--- a/src/components/TextField/TextField.tsx
+++ b/src/components/TextField/TextField.tsx
@@ -262,6 +262,8 @@ class TextField extends React.PureComponent<Props, State> {
       required,
       maxLength,
       placeholder,
+      max: type === 'date' ? '9999-12-31' : null,
+      min: type === 'date' ? '0000-01-01' : null,
       id: componentId,
       value: this.state.value,
       onFocus: this.handleInputOnFocus,


### PR DESCRIPTION
This PR resolved [45191](https://atera.tpondemand.com/RestUI/Board.aspx#page=board/4941726065867675222&appConfig=eyJhY2lkIjoiOTEwQzZFODEyODVCQ0Y4MTg5RUIyMEJEQTVDMEM2OUYifQ==&boardPopup=bug/45191/silent).