### PR TITLE
fix: id:46256 MessageChennel subscriber dropdown overlaping

### DIFF
--- a/themes/Delicious/Labelled.scss
+++ b/themes/Delicious/Labelled.scss
@@ -1,7 +1,8 @@
 $label-horizontal-spacing: spacing(tighter) * 1.5;
 
 $stacking-order: (
-  label: 25,
+  // TODO : previously it was 25. but input and select component have z-index of 20. so it was creating issue on click at component
+  label: 19,
 );
 
 


### PR DESCRIPTION
MessageChennel subscriber dropdown overlaping with sibling input and select components