### PR TITLE
fix: for hiding example dashboard content behind the left menu on load

### DIFF
--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -1113,6 +1113,7 @@ class App extends React.Component<{}, State> {
             <Button icon="infoCircle" />,
           ]}
         />
+        <div style={{padding:30, marginTop:50}}>
         <ToggleButtonGroup segmented={true} helpText="Test Help Text">
           <Button>On</Button>
           <Button>Off</Button>
@@ -3216,6 +3217,7 @@ class App extends React.Component<{}, State> {
           showSearch={true}
           searchPlaceholder="Search"
         />
+        </div>
       </div>
     );
   }

--- a/example/src/index.html
+++ b/example/src/index.html
@@ -6,6 +6,11 @@
   <meta http-equiv="X-UA-Compatible" content="ie=edge">
   <title>Emgage-UI: Example Playground</title>
   <link rel="stylesheet" href="http://sdks.shopifycdn.com/polaris/latest/polaris.css">
+  <style>
+    body #root {
+      left: 270px;
+    }
+  </style>
 </head>
 <body>
   <div id="root"></div>


### PR DESCRIPTION
Fix for hiding example dashboard content behind the left menu on load

![dashboard-after](https://user-images.githubusercontent.com/3931633/93583618-bb06a280-f9c1-11ea-9a07-ac5eac6a5ea3.PNG)
![dashboard-before](https://user-images.githubusercontent.com/3931633/93583626-bcd06600-f9c1-11ea-86bb-ebccfaa151fb.PNG)

