### PR TITLE
fix: npm run commit script

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14252,49 +14252,6 @@
         }
       }
     },
-    "inquirer-autocomplete-prompt": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/inquirer-autocomplete-prompt/-/inquirer-autocomplete-prompt-1.0.2.tgz",
-      "integrity": "sha512-vNmAhhrOQwPnUm4B9kz1UB7P98rVF1z8txnjp53r40N0PBCuqoRWqjg3Tl0yz0UkDg7rEUtZ2OZpNc7jnOU9Zw==",
-      "dev": true,
-      "requires": {
-        "ansi-escapes": "^3.0.0",
-        "chalk": "^2.0.0",
-        "figures": "^2.0.0",
-        "run-async": "^2.3.0"
-      },
-      "dependencies": {
-        "ansi-styles": {
-          "version": "3.2.1",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-          "dev": true,
-          "requires": {
-            "color-convert": "^1.9.0"
-          }
-        },
-        "chalk": {
-          "version": "2.4.2",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
-          "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-          "dev": true,
-          "requires": {
-            "ansi-styles": "^3.2.1",
-            "escape-string-regexp": "^1.0.5",
-            "supports-color": "^5.3.0"
-          }
-        },
-        "supports-color": {
-          "version": "5.5.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
-          "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-          "dev": true,
-          "requires": {
-            "has-flag": "^3.0.0"
-          }
-        }
-      }
-    },
     "internal-ip": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/internal-ip/-/internal-ip-4.3.0.tgz",
@@ -26728,6 +26685,17 @@
                 "supports-color": "^7.1.0"
               }
             }
+          }
+        },
+        "inquirer-autocomplete-prompt": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/inquirer-autocomplete-prompt/-/inquirer-autocomplete-prompt-1.1.0.tgz",
+          "integrity": "sha512-mrSeUSFGnTSid/DCKG+E+IcN4MaOnT2bW7NuSagZAguD4k3hZ0UladdYNP4EstZOwgeqv0C3M1zYa1QIIf0Oyg==",
+          "dev": true,
+          "requires": {
+            "ansi-escapes": "^4.3.1",
+            "figures": "^3.2.0",
+            "run-async": "^2.4.0"
           }
         },
         "is-fullwidth-code-point": {

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "docs": "webpack-dev-server --config webpack.docs.config",
     "precommit-msg": "echo 'Running linting and testing checks...' && exit 0",
     "travis-deploy-once": "travis-deploy-once",
-    "commit": "node node_modules/semantic-git-commit-cli/dest/cli.js",
+    "commit": "node node_modules/semantic-git-commit-cli/dest/index.js",
     "commitmsg": "commitlint -E GIT_PARAMS"
   },
   "babel": {
@@ -106,7 +106,7 @@
     "react-test-renderer": "^16.0.0",
     "sass-loader": "^7.3.1",
     "sass-resources-loader": "^2.0.1",
-    "semantic-git-commit-cli": "^3.5.0",
+    "semantic-git-commit-cli": "^3.7.0",
     "semantic-release": "^15.9.8",
     "style-loader": "^1.1.2",
     "svgo": "^0.7.2",


### PR DESCRIPTION
Fix for `npm run commit` command  

Problem: 
           npm run commit command silently exit without prompting commit options 
Reason: 
         - node node_modules/semantic-git-commit-cli/dest/cli.js => just export the function and does not execute 
         - semantic-git-commit-cli required dependency 'inquirer-autocomplete-prompt" is installed as top level
           and semantic-git-commit-cli failed to require it inside the cli.js
Fix: 
        - change the script to call node node_modules/semantic-git-commit-cli/dest/**index.js**
        - update semantic-git-commit-cli version to the latest 
        - add explicit nested dependency 'inquirer-autocomplete-prompt" to semantic-git-commit-cli to install it inside 
         ` engage-ui\node_modules\semantic-git-commit-cli\node_modules\inquirer-autocomplete-prompt   ` instead in root level