### PR TITLE
Revert "fix: for hiding example dashboard content behind the left menu on load"

### DIFF
--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -1113,7 +1113,6 @@ class App extends React.Component<{}, State> {
             <Button icon="infoCircle" />,
           ]}
         />
-        <div style={{padding:30, marginTop:50}}>
         <ToggleButtonGroup segmented={true} helpText="Test Help Text">
           <Button>On</Button>
           <Button>Off</Button>
@@ -3219,7 +3218,6 @@ class App extends React.Component<{}, State> {
           showSearch={true}
           searchPlaceholder="Search"
         />
-        </div>
       </div>
     );
   }

--- a/example/src/index.html
+++ b/example/src/index.html
@@ -6,11 +6,6 @@
   <meta http-equiv="X-UA-Compatible" content="ie=edge">
   <title>Emgage-UI: Example Playground</title>
   <link rel="stylesheet" href="http://sdks.shopifycdn.com/polaris/latest/polaris.css">
-  <style>
-    body #root {
-      left: 270px;
-    }
-  </style>
 </head>
 <body>
   <div id="root"></div>


### PR DESCRIPTION
Reverts emgage/engage-ui#535