### PR TITLE
fix id:45184 fix pages heading styles of text widget

### DIFF
--- a/src/styles/global.scss
+++ b/src/styles/global.scss
@@ -37,7 +37,6 @@ h5,
 h6,
 p {
   margin: 0;
-  font-size: 1em;
   font-weight: 400;
 }
 


### PR DESCRIPTION
Before Fix
![before_fix](https://user-images.githubusercontent.com/18735075/108059845-23d47280-7067-11eb-8ea1-cf690478aaab.png)


After fix
![after_fix](https://user-images.githubusercontent.com/18735075/108059827-1d45fb00-7067-11eb-9097-65ed4f18ce06.png)
