### PR TITLE
fix: id:52929 icon text alignment in dropdown

### DIFF
--- a/src/components/Dropdown/Dropdown.scss
+++ b/src/components/Dropdown/Dropdown.scss
@@ -73,6 +73,9 @@ $font-weight-normal: 400 !default;
     color: color(text, darkest);
       padding:1.2rem 1.6rem;
       margin:0px;
+      > span {
+        display: block;
+      }
     }
 
   &:hover {


### PR DESCRIPTION
icon text alignment in dropdown